### PR TITLE
[WIP] Lein vizdeps lives again with latest libs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/tools.cli {:mvn/version "0.4.1"}
+        com.stuartsierra/dependency {:mvn/version "0.2.0"}
+        dorothy {:mvn/version  "0.0.7"}
+        medley {:mvn/version  "1.0.0"}
+        org.clojure/tools.deps.alpha {:mvn/version "0.5.460"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,4 +4,5 @@
         com.stuartsierra/dependency {:mvn/version "0.2.0"}
         dorothy {:mvn/version  "0.0.7"}
         medley {:mvn/version  "1.0.0"}
-        org.clojure/tools.deps.alpha {:mvn/version "0.5.460"}}}
+        org.clojure/tools.deps.alpha {:mvn/version "0.5.460"}
+        }}

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,13 @@
-(defproject walmartlabs/vizdeps "0.1.7-SNAPSHOT"
+(defproject clj-commons/vizdeps "0.1.7-SNAPSHOT"
   :description "Visualize Leiningen project dependencies using Graphviz."
   :url "https://github.com/walmartlabs/vizdeps"
   :license {:name "Apache Sofware License 2.0"
             :url  "http://www.apache.org/licenses/LICENSE-2.0.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.cli "0.3.5"]
-                 [dorothy "0.0.6"]
-                 [medley "0.8.4"]
-                 [com.stuartsierra/dependency "0.2.0"]]
-  :eval-in-leiningen true)
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/tools.cli "0.4.1"]
+                 [com.stuartsierra/dependency "0.2.0"]
+                 [dorothy "0.0.7"]
+                 [medley "1.0.0"]
+                 [leiningen-core "2.8.2"]
+                 [org.apache.maven.wagon/wagon-http "3.0.0"]]
+  :aliases {"vizdeps" ["run" "-m" "clj-commons.vizdeps/leiningen"]})

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,9 @@
                  [org.clojure/tools.cli "0.4.1"]
                  [com.stuartsierra/dependency "0.2.0"]
                  [dorothy "0.0.7"]
-                 [medley "1.0.0"]
-                 [leiningen-core "2.8.2"]
-                 [org.apache.maven.wagon/wagon-http "3.0.0"]]
-  :aliases {"vizdeps" ["run" "-m" "clj-commons.vizdeps/leiningen"]})
+                 [medley "1.0.0"]]
+
+  :profiles {:leiningen {:dependencies [[leiningen-core "2.8.2"]
+                                        [org.apache.maven.wagon/wagon-http "3.0.0"]]}
+             :tools.deps {:dependencies [[org.clojure/tools.deps.alpha "0.5.460"]]}}
+  :aliases {"vizdeps" ["with-profile" "leiningen" "run" "-m" "clj-commons.leiningen.vizdeps/leiningen"]})

--- a/src/clj_commons/leiningen/common.clj
+++ b/src/clj_commons/leiningen/common.clj
@@ -5,9 +5,9 @@
 
 
 (defn flatten-dependencies
-  [project]
   "Resolves dependencies for the project and returns a map from artifact
   symbol to artifact coord vector."
+  [project]
   (-> (classpath/managed-dependency-hierarchy :dependencies :managed-dependencies
                                               project)
       common/build-dependency-map))

--- a/src/clj_commons/leiningen/common.clj
+++ b/src/clj_commons/leiningen/common.clj
@@ -1,0 +1,13 @@
+(ns clj-commons.leiningen.common
+  (:require [leiningen.core.classpath :as classpath]
+            [leiningen.core.main :as main]
+            [com.walmartlabs.vizdeps.common :as common]))
+
+
+(defn flatten-dependencies
+  [project]
+  "Resolves dependencies for the project and returns a map from artifact
+  symbol to artifact coord vector."
+  (-> (classpath/managed-dependency-hierarchy :dependencies :managed-dependencies
+                                              project)
+      common/build-dependency-map))

--- a/src/clj_commons/leiningen/vizconflicts.clj
+++ b/src/clj_commons/leiningen/vizconflicts.clj
@@ -3,6 +3,7 @@
   (:require
     [com.walmartlabs.vizdeps.common :as common
      :refer [gen-node-id]]
+    [clj-commons.leiningen.common :as lein-common]
     [medley.core :refer [map-vals remove-vals filter-vals filter-keys]]
     [clojure.pprint :refer [pprint]]
     [leiningen.core.project :as project]
@@ -188,7 +189,7 @@
   (when-let [options (common/parse-cli-options "vizconflicts" cli-options args)]
     (let [projects (projects-map project options)
           dot (->> projects
-                   (map-vals common/flatten-dependencies)
+                   (map-vals lein-common/flatten-dependencies)
                    ;; Reduce the inner maps to symbol -> version number string
                    (map-vals #(map-vals second %))
                    (artifact-versions-map options)

--- a/src/clj_commons/leiningen/vizconflicts.clj
+++ b/src/clj_commons/leiningen/vizconflicts.clj
@@ -1,4 +1,4 @@
-(ns clj-commons.vizconflicts
+(ns clj-commons.leiningen.vizconflicts
   "Graphviz visualization of conflicts in a multi-module project."
   (:require
     [com.walmartlabs.vizdeps.common :as common

--- a/src/clj_commons/leiningen/vizdeps.clj
+++ b/src/clj_commons/leiningen/vizdeps.clj
@@ -1,8 +1,9 @@
-(ns clj-commons.vizdeps
+(ns clj-commons.leiningen.vizdeps
   "Graphviz visualization of project dependencies."
   (:require
     [com.walmartlabs.vizdeps.common :as common
      :refer [gen-node-id]]
+    [clj-commons.leiningen.common :as lein-common]
     [com.stuartsierra.dependency :as dep]
     [leiningen.core.main :as main]
     [dorothy.core :as d]

--- a/src/clj_commons/leiningen/vizdeps.clj
+++ b/src/clj_commons/leiningen/vizdeps.clj
@@ -4,7 +4,6 @@
     [com.walmartlabs.vizdeps.common :as common
      :refer [gen-node-id]]
     [clj-commons.leiningen.common :as lein-common]
-    [com.stuartsierra.dependency :as dep]
     [leiningen.core.main :as main]
     [dorothy.core :as d]
     [leiningen.core.user :as user]
@@ -16,209 +15,16 @@
     [clojure.stacktrace :as stacktrace])
   (:gen-class))
 
-(defn ^:private artifact->label
-  [artifact]
-  {:pre [artifact]}
-  (let [{:keys [artifact-name version]} artifact
-        ^String group (some-> artifact-name namespace name)
-        ^String module (name artifact-name)]
-    (str group
-         (when group "/\n")
-         module
-         \newline
-         version)))
 
-(defn ^:private normalize-artifact
-  [dependency]
-  (let [artifact (first dependency)]
-    (if-not (= (namespace artifact) (name artifact))
-      dependency
-      (assoc dependency 0 (symbol (name artifact))))))
-
-(defonce crap-atom (atom nil))
-
-(defn ^:private immediate-dependencies
+(defn- get-dependencies
   [project dependency]
-  (reset! crap-atom [project dependency])
-  (if (some? dependency)
-    (-> (#'classpath/get-dependencies
-          :dependencies nil
-          (assoc project :dependencies [dependency]))
-        (get dependency)
-        ;; Tracking dependencies on Clojure itself overwhelms the graph
-        (as-> $
-              (remove #(= 'org.clojure/clojure (first %))
-                      $))
-        vec)
-    []))
-
-(declare ^:private add-dependency-tree)
-
-(defn ^:private add-dependency-node
-  [dependency-graph artifact-name artifact-version dependencies]
-  (reduce (fn [g dep]
-            (let [[dep-name dep-version] dep
-                  g-1 (add-dependency-tree g dep-name dep-version)]
-              (if-let [dep-artifact (get-in g-1 [:artifacts dep-name])]
-                (let [dep-map {:artifact-name dep-name
-                               :version dep-version
-                               :conflict? (not= dep-version
-                                                (:version dep-artifact))}]
-                  (update-in g-1 [:artifacts artifact-name :deps] conj dep-map))
-                ;; If the artifact is excluded, the dependency graph will
-                ;; not contain the artifact.
-                g-1)))
-          ;; Start with a new node for the artifact
-          (assoc-in dependency-graph
-                    [:artifacts artifact-name]
-                    {:artifact-name artifact-name
-                     :version artifact-version
-                     :node-id (gen-node-id artifact-name)
-                     :deps []})
-          dependencies))
-
-(defn ^:private add-dependency-tree
-  [dependency-graph artifact-name artifact-version]
-  (let [[_ resolved-version :as resolved-dependency] (get-in dependency-graph [:dependencies artifact-name])
-        ;; When using managed dependencies, the version (from :dependencies) may be nil,
-        ;; so subtitute the version from the resolved dependency in that case.
-        version (or artifact-version resolved-version)
-        artifact (get-in dependency-graph [:artifacts artifact-name])]
-    (main/debug (format "Processing %s %s"
-                        (str artifact-name) version))
-
-    (cond
-
-      (nil? resolved-dependency)
-      (do
-        (main/debug "Skipping excluded artifact")
-        dependency-graph)
-
-      ;; Has the artifact already been added?
-      (some? artifact)
-      dependency-graph
-
-      :else
-      (add-dependency-node dependency-graph
-                           artifact-name
-                           resolved-version
-                           ;; Find the dependencies of the resolved (not requested) artifact
-                           ;; and version. Recursively add those artifacts to the graph
-                           ;; and set up dependencies.
-                           (immediate-dependencies (:project dependency-graph)
-                                                   resolved-dependency)))))
-
-(defn ^:private dependency-order
-  "Returns the artifact names in dependency order."
-  [artifacts]
-  (let [tuples (for [artifact (vals artifacts)
-                     dep (:deps artifact)]
-                 [(:artifact-name artifact)
-                  (:artifact-name dep)])
-        graph (reduce (fn [g [artifact-name dependency-name]]
-                        (dep/depend g artifact-name dependency-name))
-                      (dep/graph)
-                      tuples)]
-    (dep/topo-sort graph)))
-
-(defn ^:private prune-artifacts
-  "Navigates the nodes to identify dependencies that include conflicts.
-  Marks nodes that are referenced with conflicts, then marks any nodes that
-  have a dependency to that node as well. The root node is always kept;
-  other unmarked nodes are culled."
-  [artifacts]
-  (main/debug "Pruning artifacts")
-  (let [order (dependency-order artifacts)
-        mark-graph (fn [artifacts artifact-name]
-                     (assoc-in artifacts [artifact-name :conflict?] true))
-        get-transitives (fn [artifacts artifact]
-                          (->> artifact
-                               :deps
-                               (filter #(->> %
-                                             :artifact-name
-                                             artifacts
-                                             ;; May be nil here, when an earlier processed artifact
-                                             ;; was culled.  Otherwise, check if the :conflict? flag
-                                             ;; was set on the artifact.
-                                             :conflict?))))
-        marked-graph (reduce (fn [artifacts-1 artifact-name]
-                               (->> (artifacts-1 artifact-name)
-                                    :deps
-                                    (filter :conflict?)
-                                    (map :artifact-name)
-                                    (reduce mark-graph artifacts-1)))
-                             artifacts
-                             order)]
-    (reduce (fn [artifacts-1 artifact-name]
-              (let [artifact (artifacts-1 artifact-name)
-                    ;; Get transitive dependencies to conflict artifacts (dropping
-                    ;; dependencies to non-conflict artifacts, if any).
-                    transitives (get-transitives artifacts-1 artifact)
-                    keep? (or (:conflict? artifact)
-                              (:root? artifact)
-                              (seq transitives))]
-                (if keep?
-                  (assoc artifacts-1 artifact-name
-                         (assoc artifact
-                                :conflict? true
-                                :deps transitives))
-                  ;; Otherwise we don't need this artifact at all
-                  (dissoc artifacts-1 artifact-name))))
-            marked-graph
-            order)))
+  (-> (#'classpath/get-dependencies
+       :dependencies nil
+       (assoc project :dependencies [dependency]))
+      (get dependency)))
 
 
-(defn ^:private highlight-artifacts
-  [artifacts highlight-terms]
-  (let [highlight-set (->> artifacts
-                           keys
-                           (filter (common/matches-any highlight-terms))
-                           set)
-        artifacts-highlighted (reduce (fn [m artifact-name]
-                                        (assoc-in m [artifact-name :highlight?] true))
-                                      artifacts
-                                      highlight-set)
-        ;; Now, find dependencies that target highlighted artifacts
-        ;; and mark them as highlighted as well.
-        add-highlight (fn [dep]
-                        (if (-> dep :artifact-name highlight-set)
-                          (assoc dep :highlight? true)
-                          dep))]
-    (reduce-kv (fn [artifacts-3 artifact-name artifact]
-                 (assoc artifacts-3 artifact-name
-                        (update artifact :deps
-                                #(map add-highlight %))))
-               {}
-               artifacts-highlighted)))
-
-(defn ^:private apply-focus
-  "Identify a number of artifacts that match a focus term.  Only keep such artifacts, and those
-  that transitively depend on them."
-  [artifacts focus-terms]
-  (let [focus-set (->> artifacts
-                       keys
-                       (filter (common/matches-any focus-terms))
-                       set)
-        keep-focus (fn [artifacts dep]
-                     (-> artifacts
-                         (get (:artifact-name dep))
-                         :focused?))
-        reducer (fn [m artifact-name]
-                  (let [artifact (get artifacts artifact-name)
-                        focus-deps (->> artifact
-                                        :deps
-                                        (filter #(keep-focus m %)))]
-                    (if (or (focus-set artifact-name)
-                            (seq focus-deps))
-                      (assoc m artifact-name
-                             (assoc artifact :focused? true
-                                    :deps focus-deps))
-                      m)))]
-    (reduce reducer
-            {}
-            (dependency-order artifacts))))
-
-(defn ^:private artifacts-map
+(defn ^:private build-dot
   "Builds a map from artifact name (symbol) to an artifact record, with keys
   :artifact-name, :version, :node-id, :highlight?, :focus?, :conflict?, :root? and
   :deps.
@@ -228,87 +34,19 @@
   (let [profiles (if-not (:dev options)
                    [:user]
                    [:user :dev])
-        {:keys [:prune highlight focus]} options
         project' (project/set-profiles project profiles)
         root-artifact-name (symbol (-> project :group str) (-> project :name str))
         root-dependency [root-artifact-name (:version project)]
-        dependency-map (common/flatten-dependencies project')
+        dependency-map (lein-common/flatten-dependencies project')
         root-dependencies (->> project'
                                :dependencies
-                               (map normalize-artifact))]
-    (-> (add-dependency-node {:artifacts {}
-                              :project project
-                              :dependencies dependency-map}
-                             root-artifact-name
-                             (:version project)
-                             root-dependencies)
-        ;; Just need the artifacts from here out
-        :artifacts
-        ;; Ensure the root artifact is drawn properly and never pruned
-        (assoc-in [root-artifact-name :root?] true)
-        (cond->
-          prune
-          prune-artifacts
+                               (map common/normalize-artifact))]
+    (common/build-dot (partial get-dependencies project)
+                      dependency-map root-artifact-name
+                      (:version project)
+                      root-dependencies
+                      options)))
 
-          (seq focus)
-          (apply-focus focus)
-
-          (seq highlight)
-          (highlight-artifacts highlight)))))
-
-(defn ^:private node-graph
-  [artifacts options]
-  (concat
-    [(d/graph-attrs (common/graph-attrs options))]
-    ;; All nodes:
-    (for [artifact (vals artifacts)]
-      [(:node-id artifact)
-       (cond-> {:label (artifact->label artifact)}
-         (:root? artifact)
-         (assoc :shape :doubleoctagon)
-
-         (:highlight? artifact)
-         (assoc :color :blue
-                :penwidth 2
-                :fontcolor :blue))])
-
-    ;; Now, all edges:
-    (for [artifact (vals artifacts)
-          :let [node-id (:node-id artifact)]
-          dep (:deps artifact)]
-      [node-id
-       (get-in artifacts [(:artifact-name dep) :node-id])
-       (cond-> {}
-         (:highlight? dep)
-         (assoc :color :blue
-                :penwidth 2
-                :weight 100)
-
-         (:conflict? dep)
-         (assoc :color :red
-                :penwidth 2
-                :weight 500
-                :label (:version dep)))])))
-
-(defn ^:private build-dot
-  [project options]
-  (-> (artifacts-map project options)
-      (node-graph options)
-      d/digraph
-      d/dot))
-
-(def ^:private cli-options
-  [["-d" "--dev" "Include :dev dependencies in the graph."]
-   ["-f" "--focus ARTIFACT" "Excludes artifacts whose names do not match a supplied value. Repeatable."
-    :assoc-fn common/conj-option]
-   ["-H" "--highlight ARTIFACT" "Highlight the artifact, and any dependencies to it, in blue. Repeatable."
-    :assoc-fn common/conj-option]
-   common/cli-no-view
-   (common/cli-output-file "target/dependencies.pdf")
-   ["-p" "--prune" "Exclude artifacts and dependencies that do not involve version conflicts."]
-   common/cli-save-dot
-   common/cli-vertical
-   common/cli-help])
 
 (defn vizdeps
   "Visualizes dependencies using Graphviz.
@@ -317,7 +55,7 @@
   Command line options allow the image to be written to a file instead."
   {:pass-through-help true}
   [project & args]
-  (when-let [options (common/parse-cli-options "vizdeps" cli-options args)]
+  (when-let [options (common/parse-cli-options "vizdeps" common/vizdeps-cli-options args)]
     (let [dot (build-dot project options)]
       (common/write-files-and-view dot options)
       (main/info "Wrote dependency chart to:" (:output-path options)))))

--- a/src/clj_commons/tools/deps/vizdeps.clj
+++ b/src/clj_commons/tools/deps/vizdeps.clj
@@ -1,0 +1,141 @@
+(ns clj-commons.tools.deps.vizdeps
+  (:require [clojure.tools.deps.alpha :as deps]
+            [com.walmartlabs.vizdeps.common :as common]
+            [dorothy.core :as d]
+            [clojure.edn :as edn]
+            [clojure.tools.deps.alpha.util.maven :as mvn]
+            [clojure.set :as c-set]
+            [dorothy.core :as dorothy-core]))
+
+
+;;We need this one inside job.
+(defn deps->tools-graph
+  [deps-edn]
+  (#'deps/expand-deps (:deps deps-edn)
+                      nil nil {:mvn/repos mvn/standard-repos} false))
+
+(def example-tools-graph
+  '{dorothy {:paths {{:mvn/version "0.0.7"} #{[]}},
+             :pin true,
+             :select {:mvn/version "0.0.7"},
+             :versions {{:mvn/version "0.0.7"} {:deps/manifest :mvn, :mvn/version "0.0.7"}}},
+    medley {:paths {{:mvn/version "1.0.0"} #{[]}},
+            :pin true,
+            :select {:mvn/version "1.0.0"},
+            :versions {{:mvn/version "1.0.0"} {:deps/manifest :mvn, :mvn/version "1.0.0"}}},
+    com.stuartsierra/dependency {:paths {{:mvn/version "0.2.0"} #{[]}},
+                                 :pin true,
+                                 :select {:mvn/version "0.2.0"},
+                                 :versions {{:mvn/version "0.2.0"} {:deps/manifest :mvn,
+                                                                    :mvn/version "0.2.0"}}},
+    org.clojure/clojure {:paths {{:mvn/version "1.9.0"} #{[]}},
+                         :pin true,
+                         :select {:mvn/version "1.9.0"},
+                         :versions {{:mvn/version "1.9.0"} {:deps/manifest :mvn,
+                                                            :mvn/version "1.9.0"}}},
+    org.clojure/core.specs.alpha {:paths {{:mvn/version "0.1.24"} #{[org.clojure/clojure]}},
+                                  :select {:mvn/version "0.1.24"},
+                                  :versions {{:mvn/version "0.1.24"} {:deps/manifest :mvn,
+                                                                      :mvn/version "0.1.24"}}},
+    org.clojure/spec.alpha {:paths {{:mvn/version "0.1.143"} #{[org.clojure/clojure]}},
+                            :select {:mvn/version "0.1.143"},
+                            :versions {{:mvn/version "0.1.143"} {:deps/manifest :mvn,
+                                                                 :mvn/version "0.1.143"}}},
+    org.clojure/tools.cli {:paths {{:mvn/version "0.4.1"} #{[]}},
+                           :pin true,
+                           :select {:mvn/version "0.4.1"},
+                           :versions {{:mvn/version "0.4.1"} {:deps/manifest :mvn,
+                                                              :mvn/version "0.4.1"}}}})
+
+
+(defn- expand-path
+  [path->nodes path]
+  (when-let [target-item (last path)]
+    (let [target-path (vec (butlast path))]
+      [target-item (get-in path->nodes [target-path target-item])])))
+
+
+(defn formalize-graph
+  [lookup-table graph maven-coord]
+  (if-let [existing (get graph (first maven-coord))]
+    graph
+    (let [item (get lookup-table maven-coord)
+          graph (assoc graph (first maven-coord)
+                       (update item :deps
+                               (fn [dep-list]
+                                 (mapv #(-> (get lookup-table
+                                                 (vec (drop-last %)))
+                                            (dissoc :deps))
+                                       dep-list))))]
+      (reduce (partial formalize-graph lookup-table)
+              graph
+              (->> (:deps item)
+                   (map (comp vec drop-last)))))))
+
+
+(defn invert-tools-deps
+  "We need to build a top-down graph of what is going on.  The tools.deps is built from
+  the opposite perspective as the vizdeps graph; so we need to 'invert' it of sorts."
+  [tools-graph]
+  (let [path-seq
+        (->> tools-graph
+             (mapcat (fn [[proj-name {:keys [paths select]}]]
+                       (->> paths
+                            (mapcat
+                             (fn [[item-version path-set]]
+                               (let [conflict? (not= item-version select)]
+                                 (map vector path-set (repeat [proj-name
+                                                               (:mvn/version item-version)
+                                                               conflict?])))))))))
+        path->nodes (->> (group-by first path-seq)
+                         (map (fn [[k v-seq]]
+                                [k (->> (map (comp vec drop-last second) v-seq)
+                                        (into {}))]))
+                         (into {}))
+        roots (get path->nodes [])
+        lookup-table (->> path-seq
+                          ;;This sort ensure that parents are added before deps
+                          (sort-by (comp count first))
+                          (reduce (fn [graph [path maven-coords]]
+                                    (let [pure-coords (vec (drop-last maven-coords))
+                                          graph (assoc graph pure-coords
+                                                       (get graph pure-coords
+                                                            {:artifact-name (first pure-coords)
+                                                             :node-id (common/gen-node-id (first pure-coords))
+                                                             :version (second pure-coords)
+                                                             :conflict? (last maven-coords)}))]
+                                      (if-let [parent-item (expand-path path->nodes path)]
+                                        (update-in graph [parent-item :deps] (fn [dep-set]
+                                                                               (if dep-set
+                                                                                 (conj dep-set maven-coords)
+                                                                                 #{maven-coords})))
+                                        graph)))
+                                  {}))
+        root-symbol (symbol "root")
+        root-version "1.0.0"
+        lookup-table (assoc lookup-table [root-symbol root-version]
+                            {:artifact-name root-symbol
+                             :version root-version
+                             :node-id (common/gen-node-id root-symbol)
+                             :root? true
+                             :deps (set (map #(conj % false) roots))})]
+    (reduce (partial formalize-graph lookup-table) {} [[root-symbol root-version]])))
+
+
+(defn build-dot
+  [fname options]
+  (let [project (edn/read-string (slurp fname))
+        deps-type-tree (expand-deps project)]
+    (-> (invert-tools-deps deps-type-tree)
+        (common/filter-dependency-graph options)
+        (common/node-graph options)
+        dorothy-core/digraph
+        dorothy-core/dot)))
+
+
+(defn vizdeps
+  [& args]
+  (let [fname (first args)]
+    (when-let [options (common/parse-cli-options "vizdeps" common/vizdeps-cli-options args)]
+      (let [dot (build-dot fname options)]
+        (common/write-files-and-view dot options)))))

--- a/src/clj_commons/vizconflicts.clj
+++ b/src/clj_commons/vizconflicts.clj
@@ -1,4 +1,4 @@
-(ns leiningen.vizconflicts
+(ns clj-commons.vizconflicts
   "Graphviz visualization of conflicts in a multi-module project."
   (:require
     [com.walmartlabs.vizdeps.common :as common

--- a/src/com/walmartlabs/vizdeps/common.clj
+++ b/src/com/walmartlabs/vizdeps/common.clj
@@ -4,9 +4,7 @@
     [clojure.java.io :as io]
     [dorothy.jvm :as d]
     [clojure.java.browse :refer [browse-url]]
-    [clojure.tools.cli :refer [parse-opts]]
-    [leiningen.core.classpath :as classpath]
-    [leiningen.core.main :as main])
+    [clojure.tools.cli :refer [parse-opts]])
   (:import (java.io File)))
 
 (defn gen-node-id
@@ -89,16 +87,13 @@
             ^File dot-file (io/file dot-path)]
         (spit dot-file dot)))
 
-    (main/debug "Create output diagram")
-
     (d/save! dot output-file {:format output-format})
 
     (when-not no-view
       (browse-url output-path)))
-
   nil)
 
-(defn ^:private build-dependency-map
+(defn build-dependency-map
   "Consumes a hierarchy and produces a map from artifact to version, used to identify
   which dependency linkages have had their version changed."
   ([hierarchy]
@@ -110,14 +105,6 @@
                     (build-dependency-map sub-hierarchy)))
               version-map
               hierarchy)))
-
-(defn flatten-dependencies
-  [project]
-  "Resolves dependencies for the project and returns a map from artifact
-  symbol to artifact coord vector."
-  (-> (classpath/managed-dependency-hierarchy :dependencies :managed-dependencies
-                                              project)
-      build-dependency-map))
 
 (defn matches-any
   "Creates a predicate that is true when the provided elem (string, symbol, keyword)

--- a/src/com/walmartlabs/vizdeps/common.clj
+++ b/src/com/walmartlabs/vizdeps/common.clj
@@ -2,7 +2,7 @@
   (:require
     [clojure.string :as str]
     [clojure.java.io :as io]
-    [dorothy.core :as d]
+    [dorothy.jvm :as d]
     [clojure.java.browse :refer [browse-url]]
     [clojure.tools.cli :refer [parse-opts]]
     [leiningen.core.classpath :as classpath]

--- a/src/com/walmartlabs/vizdeps/common.clj
+++ b/src/com/walmartlabs/vizdeps/common.clj
@@ -391,16 +391,25 @@
                 :label (:version dep)))])))
 
 
-(defonce crap-atom (atom nil))
+(defonce build-dot-example-arguments
+  '{:dependency-map {dorothy [dorothy "0.0.7"],
+                     medley [medley "1.0.0"],
+                     com.stuartsierra/dependency [com.stuartsierra/dependency "0.2.0"],
+                     org.clojure/clojure [org.clojure/clojure "1.9.0"],
+                     org.clojure/core.specs.alpha [org.clojure/core.specs.alpha "0.1.24"],
+                     org.clojure/spec.alpha [org.clojure/spec.alpha "0.1.143"],
+                     org.clojure/tools.cli [org.clojure/tools.cli "0.4.1"]},
+    :root-dependencies ([org.clojure/clojure "1.9.0"]
+                        [org.clojure/tools.cli "0.4.1"]
+                        [com.stuartsierra/dependency "0.2.0"]
+                        [dorothy "0.0.7"]
+                        [medley "1.0.0"]),
+    :root-name clj-commons/vizdeps,
+    :root-version "0.1.7-SNAPSHOT"})
 
 
 (defn build-dot
   [get-deps-fn dependency-map root-name root-version root-dependencies options]
-  (reset! crap-atom {:dependency-map dependency-map
-                     :root-name root-name
-                     :root-version root-version
-                     :root-dependencies root-dependencies
-                     })
   (-> (build-dependency-graph get-deps-fn dependency-map root-name root-version root-dependencies options)
       (node-graph options)
       dorothy-core/digraph

--- a/src/com/walmartlabs/vizdeps/common.clj
+++ b/src/com/walmartlabs/vizdeps/common.clj
@@ -3,8 +3,10 @@
     [clojure.string :as str]
     [clojure.java.io :as io]
     [dorothy.jvm :as d]
+    [com.stuartsierra.dependency :as dep]
     [clojure.java.browse :refer [browse-url]]
-    [clojure.tools.cli :refer [parse-opts]])
+    [clojure.tools.cli :refer [parse-opts]]
+    [dorothy.core :as dorothy-core])
   (:import (java.io File)))
 
 (defn gen-node-id
@@ -60,6 +62,21 @@
 
   nil)
 
+
+(def vizdeps-cli-options
+  [["-d" "--dev" "Include :dev dependencies in the graph."]
+   ["-f" "--focus ARTIFACT" "Excludes artifacts whose names do not match a supplied value. Repeatable."
+    :assoc-fn conj-option]
+   ["-H" "--highlight ARTIFACT" "Highlight the artifact, and any dependencies to it, in blue. Repeatable."
+    :assoc-fn conj-option]
+   cli-no-view
+   (cli-output-file "target/dependencies.pdf")
+   ["-p" "--prune" "Exclude artifacts and dependencies that do not involve version conflicts."]
+   cli-save-dot
+   cli-vertical
+   cli-help])
+
+
 (defn parse-cli-options
   "Parses the CLI options; handles --help and errors (returning nil) or just
   returns the parsed options."
@@ -113,3 +130,278 @@
   (fn [elem]
     (let [elem-name (name elem)]
       (some #(str/includes? elem-name %) names))))
+
+
+(defn artifact->label
+  [artifact]
+  {:pre [artifact]}
+  (let [{:keys [artifact-name version]} artifact
+        ^String group (some-> artifact-name namespace name)
+        ^String module (name artifact-name)]
+    (str group
+         (when group "/\n")
+         module
+         \newline
+         version)))
+
+
+(defn normalize-artifact
+  [dependency]
+  (let [artifact (first dependency)]
+    (if-not (= (namespace artifact) (name artifact))
+      dependency
+      (assoc dependency 0 (symbol (name artifact))))))
+
+
+(defn dependency-order
+  "Returns the artifact names in dependency order."
+  [artifacts]
+  (let [tuples (for [artifact (vals artifacts)
+                     dep (:deps artifact)]
+                 [(:artifact-name artifact)
+                  (:artifact-name dep)])
+        graph (reduce (fn [g [artifact-name dependency-name]]
+                        (dep/depend g artifact-name dependency-name))
+                      (dep/graph)
+                      tuples)]
+    (dep/topo-sort graph)))
+
+(defn prune-artifacts
+  "Navigates the nodes to identify dependencies that include conflicts.
+  Marks nodes that are referenced with conflicts, then marks any nodes that
+  have a dependency to that node as well. The root node is always kept;
+  other unmarked nodes are culled."
+  [artifacts]
+  (let [order (dependency-order artifacts)
+        mark-graph (fn [artifacts artifact-name]
+                     (assoc-in artifacts [artifact-name :conflict?] true))
+        get-transitives (fn [artifacts artifact]
+                          (->> artifact
+                               :deps
+                               (filter #(->> %
+                                             :artifact-name
+                                             artifacts
+                                             ;; May be nil here, when an earlier processed artifact
+                                             ;; was culled.  Otherwise, check if the :conflict? flag
+                                             ;; was set on the artifact.
+                                             :conflict?))))
+        marked-graph (reduce (fn [artifacts-1 artifact-name]
+                               (->> (artifacts-1 artifact-name)
+                                    :deps
+                                    (filter :conflict?)
+                                    (map :artifact-name)
+                                    (reduce mark-graph artifacts-1)))
+                             artifacts
+                             order)]
+    (reduce (fn [artifacts-1 artifact-name]
+              (let [artifact (artifacts-1 artifact-name)
+                    ;; Get transitive dependencies to conflict artifacts (dropping
+                    ;; dependencies to non-conflict artifacts, if any).
+                    transitives (get-transitives artifacts-1 artifact)
+                    keep? (or (:conflict? artifact)
+                              (:root? artifact)
+                              (seq transitives))]
+                (if keep?
+                  (assoc artifacts-1 artifact-name
+                         (assoc artifact
+                                :conflict? true
+                                :deps transitives))
+                  ;; Otherwise we don't need this artifact at all
+                  (dissoc artifacts-1 artifact-name))))
+            marked-graph
+            order)))
+
+
+(defn highlight-artifacts
+  [artifacts highlight-terms]
+  (let [highlight-set (->> artifacts
+                           keys
+                           (filter (matches-any highlight-terms))
+                           set)
+        artifacts-highlighted (reduce (fn [m artifact-name]
+                                        (assoc-in m [artifact-name :highlight?] true))
+                                      artifacts
+                                      highlight-set)
+        ;; Now, find dependencies that target highlighted artifacts
+        ;; and mark them as highlighted as well.
+        add-highlight (fn [dep]
+                        (if (-> dep :artifact-name highlight-set)
+                          (assoc dep :highlight? true)
+                          dep))]
+    (reduce-kv (fn [artifacts-3 artifact-name artifact]
+                 (assoc artifacts-3 artifact-name
+                        (update artifact :deps
+                                #(map add-highlight %))))
+               {}
+               artifacts-highlighted)))
+
+
+(defn apply-focus
+  "Identify a number of artifacts that match a focus term.  Only keep such artifacts, and those
+  that transitively depend on them."
+  [artifacts focus-terms]
+  (let [focus-set (->> artifacts
+                       keys
+                       (filter (matches-any focus-terms))
+                       set)
+        keep-focus (fn [artifacts dep]
+                     (-> artifacts
+                         (get (:artifact-name dep))
+                         :focused?))
+        reducer (fn [m artifact-name]
+                  (let [artifact (get artifacts artifact-name)
+                        focus-deps (->> artifact
+                                        :deps
+                                        (filter #(keep-focus m %)))]
+                    (if (or (focus-set artifact-name)
+                            (seq focus-deps))
+                      (assoc m artifact-name
+                             (assoc artifact :focused? true
+                                    :deps focus-deps))
+                      m)))]
+    (reduce reducer
+            {}
+            (dependency-order artifacts))))
+
+
+(def ^:dynamic *get-dependencies*)
+
+
+(defn ^:private immediate-dependencies
+  [dependency]
+  (if (some? dependency)
+    (->> (*get-dependencies* dependency)
+         (remove #(= 'org.clojure/clojure (first %)))
+         vec)
+    []))
+
+
+(declare ^:private add-dependency-tree)
+
+(defn add-dependency-node
+  [dependency-graph artifact-name artifact-version dependencies]
+  (reduce (fn [g dep]
+            (let [[dep-name dep-version] dep
+                  g-1 (add-dependency-tree g dep-name dep-version)]
+              (if-let [dep-artifact (get-in g-1 [:artifacts dep-name])]
+                (let [dep-map {:artifact-name dep-name
+                               :version dep-version
+                               :conflict? (not= dep-version
+                                                (:version dep-artifact))}]
+                  (update-in g-1 [:artifacts artifact-name :deps] conj dep-map))
+                ;; If the artifact is excluded, the dependency graph will
+                ;; not contain the artifact.
+                g-1)))
+          ;; Start with a new node for the artifact
+          (assoc-in dependency-graph
+                    [:artifacts artifact-name]
+                    {:artifact-name artifact-name
+                     :version artifact-version
+                     :node-id (gen-node-id artifact-name)
+                     :deps []})
+          dependencies))
+
+
+(defn ^:private add-dependency-tree
+  [dependency-graph artifact-name artifact-version]
+  (let [[_ resolved-version :as resolved-dependency] (get-in dependency-graph [:dependencies artifact-name])
+        ;; When using managed dependencies, the version (from :dependencies) may be nil,
+        ;; so subtitute the version from the resolved dependency in that case.
+        version (or artifact-version resolved-version)
+        artifact (get-in dependency-graph [:artifacts artifact-name])]
+
+    ;; (main/debug (format "Processing %s %s"
+    ;;                     (str artifact-name) version))
+
+    (cond
+
+      (nil? resolved-dependency)
+      dependency-graph
+
+      ;; Has the artifact already been added?
+      (some? artifact)
+      dependency-graph
+
+      :else
+      (add-dependency-node dependency-graph
+                           artifact-name
+                           resolved-version
+                           ;; Find the dependencies of the resolved (not requested) artifact
+                           ;; and version. Recursively add those artifacts to the graph
+                           ;; and set up dependencies.
+                           (immediate-dependencies resolved-dependency)))))
+
+
+(defn build-dependency-graph
+  [get-deps-fn dependency-map root-name root-version root-dependencies options]
+  (let [{:keys [prune highlight focus]} options]
+    (with-bindings {#'*get-dependencies* get-deps-fn}
+      (-> (add-dependency-node {:artifacts {}
+                                :dependencies dependency-map}
+                               root-name
+                               root-version
+                               root-dependencies)
+          ;; Just need the artifacts from here out
+          :artifacts
+          ;; Ensure the root artifact is drawn properly and never pruned
+          (assoc-in [root-name :root?] true)
+          (cond->
+              prune
+            prune-artifacts
+
+            (seq focus)
+            (apply-focus focus)
+
+            (seq highlight)
+            (highlight-artifacts highlight))))))
+
+
+(defn node-graph
+  [artifacts options]
+  (concat
+    [(dorothy-core/graph-attrs (graph-attrs options))]
+    ;; All nodes:
+    (for [artifact (vals artifacts)]
+      [(:node-id artifact)
+       (cond-> {:label (artifact->label artifact)}
+         (:root? artifact)
+         (assoc :shape :doubleoctagon)
+
+         (:highlight? artifact)
+         (assoc :color :blue
+                :penwidth 2
+                :fontcolor :blue))])
+
+    ;; Now, all edges:
+    (for [artifact (vals artifacts)
+          :let [node-id (:node-id artifact)]
+          dep (:deps artifact)]
+      [node-id
+       (get-in artifacts [(:artifact-name dep) :node-id])
+       (cond-> {}
+         (:highlight? dep)
+         (assoc :color :blue
+                :penwidth 2
+                :weight 100)
+
+         (:conflict? dep)
+         (assoc :color :red
+                :penwidth 2
+                :weight 500
+                :label (:version dep)))])))
+
+
+(defonce crap-atom (atom nil))
+
+
+(defn build-dot
+  [get-deps-fn dependency-map root-name root-version root-dependencies options]
+  (reset! crap-atom {:dependency-map dependency-map
+                     :root-name root-name
+                     :root-version root-version
+                     :root-dependencies root-dependencies
+                     })
+  (-> (build-dependency-graph get-deps-fn dependency-map root-name root-version root-dependencies options)
+      (node-graph options)
+      dorothy-core/digraph
+      dorothy-core/dot))


### PR DESCRIPTION
Here is the minimal set of changes required to get vizdeps to work at all with latest libs.

dorothy requires clojure 1.9.0; leiningen plugins are [fixed](https://github.com/technomancy/leiningen/issues/2433) to clojure 1.8.0 for the foreseeable future.


The solution seems to be to include leingingen-core directly and change a few things because leiningen's internal API has changed a bit.


I propose:

1.  Move forward with alias pathway.  Forcing an alias is only minimally more work than using a plugin *and* allows freedom to upgrade to newer versions of clojure.

2.   Suppport tools.deps.alpha.  This means: 
   * abstract leiningen specific things into vizdeps/leiningen.clj
   * create vizdeps/tools.deps.clj
   * potentially support direct aether or boot systems in a similar fashion.

Thoughts?