### PR TITLE
Smallest change possible to get this to work with leiningen 2.8.3

### DIFF
--- a/src/leiningen/vizdeps.clj
+++ b/src/leiningen/vizdeps.clj
@@ -32,10 +32,9 @@
 (defn ^:private immediate-dependencies
   [project dependency]
   (if (some? dependency)
-    (-> (#'classpath/get-dependencies-memoized
+    (-> (#'classpath/get-dependencies
           :dependencies nil
-          (assoc project :dependencies [dependency])
-          nil)
+          (assoc project :dependencies [dependency]))
         (get dependency)
         ;; Tracking dependencies on Clojure itself overwhelms the graph
         (as-> $


### PR DESCRIPTION
I don't know if this is backward compatible.

Still calling leiningen internal functions but get-dependencies-memized is now wrapped with a with-binding internal to the leiningen classpath system so this project cannot call into it.