### PR TITLE
Match artifacts based on their full label using regular expressions

### DIFF
--- a/src/com/walmartlabs/vizdeps/common.clj
+++ b/src/com/walmartlabs/vizdeps/common.clj
@@ -121,8 +121,10 @@
 
 (defn matches-any
   "Creates a predicate that is true when the provided elem (string, symbol, keyword)
-  matches any of the provided string names."
-  [names]
-  (fn [elem]
-    (let [elem-name (name elem)]
-      (some #(str/includes? elem-name %) names))))
+  matches any of the provided string labels, each of which can be a regular expression
+  (string, re-pattern)"
+  [labels]
+  (let [patterns (map re-pattern labels)]
+    (fn [elem]
+      (let [elem-label (str elem)]
+        (some #(re-find % elem-label) patterns)))))


### PR DESCRIPTION
Currently vizdeps matches artifacts based on substring inclusion, and only looks at the artifact ID, excluding the group ID. It can be helpful (for example, to only show dependencies within a certain group ID) to match on the entire "label" of an artifact (that is, `{groupid}/{artifactid}`). Additionally, allowing the `--focus`, etc., arguments to be regular expressions in addition to just substrings can help find dependencies that are, perhaps, controlled by one entity/company, but that use slightly different groupids.

Example usage:
```
lein vizdeps -f "org\\.apache\.*commons"
```